### PR TITLE
Added --no-crop feature, several improvements and new documentation, conflicts are solved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store
+
+pics/
+
+tests/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Contact Sheet Generator
 
 Contact Sheet Generator is a Python script that generates a contact sheet from a directory of images. It uses the `PIL` library to process images and `multiprocessing` to generate thumbnails in parallel. The contact sheet is created by arranging the thumbnails in a grid pattern.
+ 
+Also, it generates grid pattern without cropping the images. It supports both vertical and horizontal. All images automatically fit into the final grid pattern. You can use this feature with ```--no-crop``` argument in command line.
 
 ## Requirements
 
@@ -8,6 +10,7 @@ Contact Sheet Generator is a Python script that generates a contact sheet from a
 - `PIL` library (`pillow` package)
 - `multiprocessing` module
 - `tqdm` library
+- `rectpack` library
 
 ## Usage
 
@@ -20,7 +23,7 @@ git clone https://github.com/cobanov/contact-sheet-generator.git
 2. Install the required dependencies.
 
 ```shell
-pip install pillow tqdm
+pip install -r requirements.txt
 ```
 
 3. Place your images in a directory.
@@ -30,8 +33,20 @@ pip install pillow tqdm
 5. Run the script with the following command:
 
 ```shell
-python contact_sheet_generator.py /path/to/images output_contact_sheet.jpg
+python contact_sheet.py /path/to/images output_contact_sheet.jpg
 ```
+6. Also, you can specify options with additional arguments (**--img-size ,  --no-crop**)
+```shell
+python contract_sheet.py /path/to/images --img-size 500 --no-crop result.jpg
+```
+## Arguments 
+| Name             | Type | Description 
+| ----------------- | ------------- | ----------- |
+| --img-size(optional) | **int** | Adjust image size to process |
+| --no-crop(optional) | **bool** | Create without cropping images, support v&h pictures|
+| output_file | **string** | Output file name|
+| image_dir| **string** | Path of image directory
+
 
 Replace /path/to/images with the directory path containing the images you want to generate a contact sheet from, and output_contact_sheet.jpg with the desired output file path for the contact sheet.
 
@@ -57,6 +72,11 @@ The temporary thumbnail directory used during the process will be cleaned up aut
 
 Feel free to modify and customize the script according to your specific requirements!
 
+
+## Authors
+
+- [@cobanov](https://github.com/cobanov/)
+- [@egemengulpinar](https://www.github.com/egemengulpinar)
 ## License
 
 This project is licensed under the [MIT License](https://choosealicense.com/licenses/mit/)

--- a/README.md
+++ b/README.md
@@ -39,14 +39,7 @@ python contact_sheet.py /path/to/images output_contact_sheet.jpg
 ```shell
 python contract_sheet.py /path/to/images --img-size 500 --no-crop result.jpg
 ```
-## Arguments 
-| Name             | Type | Description 
-| ----------------- | ------------- | ----------- |
-| --image_dir | **str** | Path of image directory |
-| --file_list(optional) | **str** | Path to the file list (filelist.txt) if available |
-| --img-size(optional) | **int** | Adjust image size to process |
-| --no-crop(optional) | **bool** | Create without cropping images, support v&h pictures|
-| output_file | **str** | Output file name|
+
 
 
 
@@ -56,6 +49,15 @@ Replace /path/to/images with the directory path containing the images you want t
 6. The script will start generating the contact sheet and display progress bars using the tqdm library.
 
 7. Once the process completes, the contact sheet will be saved to the specified output file path.
+
+## Arguments 
+| Name             | Type | Description 
+| ----------------- | ------------- | ----------- |
+| --image_dir | **str** | Path of image directory |
+| --file_list(optional) | **str** | Path to the file list (filelist.txt) if available |
+| --img-size(optional) | **int** | Adjust image size to process |
+| --no-crop(optional) | **bool** | Create without cropping images, support v&h pictures|
+| output_file | **str** | Output file name|
 
 ## Output
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Pillow
 tqdm
+rectpack

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,45 @@
+from PIL import Image
+import os
+from rectpack import newPacker
+from tqdm import tqdm
+import math
+accepted_extensions = (".jpg", ".jpeg", ".png")
+
+def create_contact_sheet_no_crop(img_dir, output_file, img_size):
+    images = []  # list to hold image objects
+    sizes = []  # list to hold sizes of each image
+    total_size = 0  # total size of all images
+    if img_size == 0:
+        img_size = len(os.listdir(img_dir))
+
+        
+    for filename in os.listdir(img_dir)[0:img_size]:
+        if filename.lower().endswith(accepted_extensions):
+            path = os.path.join(img_dir, filename)
+            img = Image.open(path)
+            images.append(img)
+            sizes.append(img.size)
+            total_size += img.size[0] * img.size[1]
+
+    # calculate the side of a square that can contain all images
+    side = int(math.sqrt(total_size))
+    # create a new packer
+    packer = newPacker(rotation=False)
+
+    # add the rectangles to packing queue
+    for i, size in enumerate(sizes):
+        packer.add_rect(*size, i) 
+
+    # add the bin (final image)
+    packer.add_bin(side, side)
+
+    # start packing
+    packer.pack()
+
+    # full bin packing
+    all_rects = packer.rect_list()
+    # create a blank canvas
+    contact_sheet = Image.new('RGB', (side, side))
+
+    return contact_sheet,all_rects,images
+

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,6 @@ def create_contact_sheet_no_crop(image_paths, output_file, img_size):
             images.append(img)
             sizes.append(img.size)
             total_size += img.size[0] * img.size[1]
-            print("FINISHED1")
 
     # calculate the side of a square that can contain all images
     side = int(math.sqrt(total_size))
@@ -27,7 +26,6 @@ def create_contact_sheet_no_crop(image_paths, output_file, img_size):
     # add the rectangles to packing queue
     for i, size in enumerate(sizes):
         packer.add_rect(*size, i) 
-    print("FINISHED2")
 
     # add the bin (final image)
     packer.add_bin(side, side)
@@ -41,7 +39,6 @@ def create_contact_sheet_no_crop(image_paths, output_file, img_size):
 
     # create a blank canvas
     contact_sheet = Image.new('RGB', (side, side))
-    print("FINISHED4")
 
     return contact_sheet,all_rects,images
 


### PR DESCRIPTION
- This 2nd pull request is convenient with the new version of the main branch. All conflicts are fixed.
- Created a new option for the **no_crop** feature. That supports to fit vertical and horizontal pictures without any crop process. In the previous version, sometimes images do not seem clear after the central crop. I add an alternative option for that issue. In some picture sizes, there was an empty black grid pattern on the bottom. As can be seen below I demonstrated the difference.

  ## Previous version
    <img width="396" alt="Ekran Resmi 2023-06-01 16 08 07" src="https://github.com/cobanov/contact-sheet/assets/71253469/da492c6b-2eb3-4436-b43b-19d96721b6d3">
    
  ## With **no_crop** feature
    <img width="452" alt="Ekran Resmi 2023-06-01 16 07 34" src="https://github.com/cobanov/contact-sheet/assets/71253469/b28add20-5d5a-4616-9a44-77d4a34dbc7d">


- Added argument in the main script that gives functionality for users can set the **image size** from the command line
- Added new arguments for both features(**--img-size** and **--no-crop**) 
- Created a new **Readme.md** file, added new documentation steps
- Updated **requirements.txt**



